### PR TITLE
Бафф магистрата

### DIFF
--- a/Resources/Prototypes/ADT/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/ADT/Loadouts/role_loadouts.yml
@@ -5,7 +5,7 @@
   - GroupTankHarness
   - MagistratNeck
   - MagistratJumpsuit
-  - CommonBackpack
+  - LawyerBackpack
   - ADTLawyerGloves # ADT-Tweak
   - LawyerShoes
   - Glasses

--- a/Resources/Prototypes/ADT/Roles/Jobs/Juridical/Magistrat.yml
+++ b/Resources/Prototypes/ADT/Roles/Jobs/Juridical/Magistrat.yml
@@ -53,17 +53,19 @@
     shoes: ClothingShoesBootsLaceup
     #mask: Ну что за косипор оставляет пустуе значения?
     #outerClothing: ClothingOuterRobesJudge
-    eyes: ClothingEyesGlassesSunglasses
+    eyes: ClothingEyesGlassesCommand
     #head: ClothingHeadHatPwig
     id: MagistratPDA
     #gloves:
     ears: ClothingHeadsetMagistrat
-    #belt:
-    neck: ClothingNeckLawyerbadge
+    belt: ClothingBeltStorageWaistbag
+    #neck: ClothingNeckLawyerbadge
     pocket2: RubberStampMagisrat
   storage:
     back:
     - Flash
+    - WeaponDisabler
+    - zipties
   # ADT-TelescopicBaton
     - ADTtelescopicBaton
   # ADT-TelescopicBaton

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -255,12 +255,18 @@
   - PassengerGloves
 
 - type: loadoutGroup
-  id: CommonBackpack
+  id: Backpack
   name: loadout-group-backpack
   loadouts:
   - CommonBackpack
   - CommonSatchel
   - CommonDuffel
+
+- type: loadoutGroup
+  id: LawyerBackpack
+  name: loadout-group-lawyer-backpack
+  loadouts:
+  - ClothingBackpackSatchelLeather
 
 - type: loadoutGroup
   id: PassengerNeck


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
НТ вспомнило о бедности на магистрате и выделило ему административные очки, станнер и стяжки. Также теперь заместо обычного рюкзака он носит шикарную кожаную сумку
## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс. -->
Магистрат, будучи "большой шишкой", не имел оружия самооборны помимо дубинки - исправили. На баланс не повлияет почти никак.
Ссылка на заказ, предложение или баг-репорт
- [Баг-репорт/Заказ/Предложение](ссылка)-->
https://discord.com/channels/901772674865455115/1397950202194694204

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
Добавлена новая группа рюкзаков - LawyerBackpack. Представляет из себя всего одну кожаную сумку. Слегка изменён файл магистрата
## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог

# ❗❗ УДАЛЯЙТЕ КОММЕНТЫ НИЖЕ И ПИШИТЕ no cl, no fun ЕСЛИ НИ ХОТИТЕ ЭТОГО В ЧЕЙНЖЛОГИ  ❗❗
# ❗❗ НЕ МЕРДЖИТЬ ПОКА НЕ УДАЛИТЕ  ❗❗
# ❗❗ ↓↓↓ ВОТ ЭТИ ↓↓↓ ❗❗
<!--
:cl: (Автор изменения)
- add: Добавлены станнер, стяжки в лоадаут магистрату
- tweak: Изменены очки магистрата с обычных на административные 
-->
# ❗❗ ↑↑↑ УДАЛЯЙТЕ КОММЕНТЫ ↑↑↑ ❗❗
